### PR TITLE
[18.0] [FIX] purchase_triple_discount: restore default_supplierinfo_discount(s)

### DIFF
--- a/purchase_triple_discount/README.rst
+++ b/purchase_triple_discount/README.rst
@@ -61,6 +61,8 @@ Unit price: 600.00 ->
    the corresponding vendor pricelist.
 -  Vendor pricelists can be edited as well with their corresponding new
    second and third discounts.
+-  A default second or third discount can be set in every vendor *Sale &
+   Purchases* tab.
 
 Bug Tracker
 ===========

--- a/purchase_triple_discount/__manifest__.py
+++ b/purchase_triple_discount/__manifest__.py
@@ -15,6 +15,7 @@
     "data": [
         "views/product_supplierinfo_view.xml",
         "views/purchase_view.xml",
+        "views/res_partner_view.xml",
     ],
     "post_init_hook": "post_init_hook",
     "installable": True,

--- a/purchase_triple_discount/models/__init__.py
+++ b/purchase_triple_discount/models/__init__.py
@@ -2,3 +2,4 @@ from . import purchase_triple_discount_mixin
 from . import product_supplierinfo
 from . import purchase_order_line
 from . import purchase_order
+from . import res_partner

--- a/purchase_triple_discount/models/product_supplierinfo.py
+++ b/purchase_triple_discount/models/product_supplierinfo.py
@@ -1,10 +1,34 @@
 # Copyright 2019 Tecnativa - David Vidal
 # Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from odoo import models
+from odoo import api, models
 
 
 class ProductSupplierInfo(models.Model):
     _name = "product.supplierinfo"
     _inherit = ["purchase.triple.discount.mixin", "product.supplierinfo"]
+
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        self.update(
+            {
+                field: self.partner_id[f"default_supplierinfo_{field}"]
+                for field in self._get_multiple_discount_field_names()
+            }
+        )
+
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        res.update(
+            {
+                field: self.partner_id[f"default_supplierinfo_{field}"]
+                for field in self._get_multiple_discount_field_names()
+            }
+        )
+        return res
+
+    @api.model
+    def _get_po_to_supplierinfo_synced_fields(self):
+        res = super()._get_po_to_supplierinfo_synced_fields()
+        res += self._get_multiple_discount_field_names()
+        return res

--- a/purchase_triple_discount/models/res_partner.py
+++ b/purchase_triple_discount/models/res_partner.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Tecnativa - David Vidal
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    default_supplierinfo_discount1 = fields.Float(
+        string="Default Supplier Discount 1 (%)",
+        digits="Discount",
+        help="This value will be used as the default one, for each new "
+        "supplierinfo line depending on that supplier.",
+    )
+
+    default_supplierinfo_discount2 = fields.Float(
+        string="Default Supplier Discount 2 (%)",
+        digits="Discount",
+        help="This value will be used as the default one, for each new "
+        "supplierinfo line depending on that supplier.",
+    )
+    default_supplierinfo_discount3 = fields.Float(
+        string="Default Supplier Discount 3 (%)",
+        digits="Discount",
+        help="This value will be used as the default one, for each new "
+        "supplierinfo line depending on that supplier.",
+    )

--- a/purchase_triple_discount/readme/USAGE.md
+++ b/purchase_triple_discount/readme/USAGE.md
@@ -20,3 +20,5 @@ Unit price: 600.00 -\>
   the corresponding vendor pricelist.
 - Vendor pricelists can be edited as well with their corresponding new
   second and third discounts.
+- A default second or third discount can be set in every vendor *Sale &
+  Purchases* tab.

--- a/purchase_triple_discount/static/description/index.html
+++ b/purchase_triple_discount/static/description/index.html
@@ -412,6 +412,8 @@ be calculated over discount 1 and discount 3 over the result of discount
 the corresponding vendor pricelist.</li>
 <li>Vendor pricelists can be edited as well with their corresponding new
 second and third discounts.</li>
+<li>A default second or third discount can be set in every vendor <em>Sale &amp;
+Purchases</em> tab.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/purchase_triple_discount/views/res_partner_view.xml
+++ b/purchase_triple_discount/views/res_partner_view.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <record model="ir.ui.view" id="view_partner_property_form_inherit_triple_discount">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="purchase.view_partner_property_form" />
+        <field name="arch" type="xml">
+            <field name="buyer_id" position="after">
+                <field
+                    name="default_supplierinfo_discount1"
+                    invisible="not is_company or parent_id"
+                />
+                <field
+                    name="default_supplierinfo_discount2"
+                    invisible="not is_company or parent_id"
+                />
+                <field
+                    name="default_supplierinfo_discount3"
+                    invisible="not is_company or parent_id"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
I restored default supplier discount fields on partner form.